### PR TITLE
Add Moya-based API client with integration tests

### DIFF
--- a/APIModule/Package.swift
+++ b/APIModule/Package.swift
@@ -13,7 +13,9 @@ let package = Package(
         .library(name: "Composition", targets: ["Composition"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Moya/Moya.git", from: "15.0.3")
+        .package(url: "https://github.com/Moya/Moya.git", from: "15.0.3"),
+        .package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.8.1"),
+        .package(url: "https://github.com/pointfreeco/swift-dependencies.git", from: "1.0.0")
     ],
     targets: [
         .target(
@@ -29,7 +31,9 @@ let package = Package(
             name: "Data",
             dependencies: [
                 "Domain",
-                .product(name: "Moya", package: "Moya")
+                .product(name: "Moya", package: "Moya"),
+                .product(name: "Alamofire", package: "Alamofire"),
+                .product(name: "Dependencies", package: "swift-dependencies")
             ],
             path: "Sources/Data",
             swiftSettings: [
@@ -52,7 +56,12 @@ let package = Package(
         ),
         .testTarget(
             name: "DataTests",
-            dependencies: ["Data"],
+            dependencies: [
+                "Data",
+                .product(name: "Moya", package: "Moya"),
+                .product(name: "Alamofire", package: "Alamofire"),
+                .product(name: "Dependencies", package: "swift-dependencies")
+            ],
             path: "Tests/DataTests",
             swiftSettings: [
                 .unsafeFlags(["-strict-concurrency=complete"], .when(configuration: .debug)),

--- a/APIModule/Package.swift
+++ b/APIModule/Package.swift
@@ -6,7 +6,8 @@ import PackageDescription
 let package = Package(
     name: "APIModule",
     platforms: [
-        .iOS(.v18)
+        .iOS(.v18),
+        .macOS(.v10_15)
     ],
     products: [
         .library(name: "Domain", targets: ["Domain"]),

--- a/APIModule/Sources/Data/APIClient.swift
+++ b/APIModule/Sources/Data/APIClient.swift
@@ -4,7 +4,7 @@ import Domain
 import Moya
 
 @MainActor
-public final class APIClient: APIRequesting {
+public final class APIClient: @preconcurrency APIRequesting {
     @Dependency(\.network) private var network
 
     public init() {}

--- a/APIModule/Sources/Data/APIClient.swift
+++ b/APIModule/Sources/Data/APIClient.swift
@@ -1,14 +1,21 @@
-//
-//  APIClient.swift
-//  APIClientSample
-//  
-//  Created by Daiki Fujimori on 2025/08/23
-//  
-
+import Foundation
+import Dependencies
 import Domain
 import Moya
 
-package final class APIClient: APIRequesting {
+public final class APIClient: APIRequesting {
+    @Dependency(\.network) private var network
 
-    package init() {}
+    public init() {}
+
+    public func fetchUser(id: String, completion: @escaping (Result<Data, Error>) -> Void) {
+        network.request(UserAPI.getUser(id: id), callbackQueue: .main, progress: nil) { result in
+            switch result {
+            case .success(let response):
+                completion(.success(response.data))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
 }

--- a/APIModule/Sources/Data/APIClient.swift
+++ b/APIModule/Sources/Data/APIClient.swift
@@ -3,6 +3,7 @@ import Dependencies
 import Domain
 import Moya
 
+@MainActor
 public final class APIClient: APIRequesting {
     @Dependency(\.network) private var network
 

--- a/APIModule/Sources/Data/Dependencies+Network.swift
+++ b/APIModule/Sources/Data/Dependencies+Network.swift
@@ -7,7 +7,10 @@ public enum NetworkProviderKey: DependencyKey {
         return MoyaNetworkProvider(session: session, plugins: [])
     }()
     public static var testValue: NetworkProviding {
-        unimplemented("NetworkProviding.testValue is not set")
+        unimplemented(
+            "NetworkProviding.testValue is not set",
+            placeholder: MoyaNetworkProvider(session: Session(configuration: .default))
+        )
     }
 }
 

--- a/APIModule/Sources/Data/Dependencies+Network.swift
+++ b/APIModule/Sources/Data/Dependencies+Network.swift
@@ -1,0 +1,19 @@
+import Dependencies
+import Alamofire
+
+public enum NetworkProviderKey: DependencyKey {
+    public static let liveValue: NetworkProviding = {
+        let session = Session(configuration: .default)
+        return MoyaNetworkProvider(session: session, plugins: [])
+    }()
+    public static var testValue: NetworkProviding {
+        unimplemented("NetworkProviding.testValue is not set")
+    }
+}
+
+public extension DependencyValues {
+    var network: NetworkProviding {
+        get { self[NetworkProviderKey.self] }
+        set { self[NetworkProviderKey.self] = newValue }
+    }
+}

--- a/APIModule/Sources/Data/NetworkProviding.swift
+++ b/APIModule/Sources/Data/NetworkProviding.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Moya
+import Alamofire
+
+public protocol NetworkProviding {
+    var session: Alamofire.Session { get }
+    func request(
+        _ target: TargetType,
+        callbackQueue: DispatchQueue?,
+        progress: ProgressBlock?,
+        completion: @escaping Completion
+    )
+}
+
+public struct MoyaNetworkProvider: NetworkProviding {
+    public let session: Alamofire.Session
+    private let provider: MoyaProvider<MultiTarget>
+
+    public init(session: Alamofire.Session, plugins: [PluginType] = []) {
+        self.session = session
+        self.provider = MoyaProvider<MultiTarget>(
+            session: session,
+            plugins: plugins
+        )
+    }
+
+    public func request(
+        _ target: TargetType,
+        callbackQueue: DispatchQueue? = nil,
+        progress: ProgressBlock? = nil,
+        completion: @escaping Completion
+    ) {
+        provider.request(
+            MultiTarget(target),
+            callbackQueue: callbackQueue,
+            progress: progress,
+            completion: completion
+        )
+    }
+}

--- a/APIModule/Sources/Data/NetworkProviding.swift
+++ b/APIModule/Sources/Data/NetworkProviding.swift
@@ -2,7 +2,7 @@ import Foundation
 import Moya
 import Alamofire
 
-public protocol NetworkProviding {
+public protocol NetworkProviding: Sendable {
     var session: Alamofire.Session { get }
     func request(
         _ target: TargetType,
@@ -38,3 +38,5 @@ public struct MoyaNetworkProvider: NetworkProviding {
         )
     }
 }
+
+extension MoyaNetworkProvider: @unchecked Sendable {}

--- a/APIModule/Sources/Data/UserAPI.swift
+++ b/APIModule/Sources/Data/UserAPI.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Moya
+
+public enum UserAPI {
+    case getUser(id: String)
+}
+
+extension UserAPI: TargetType {
+    public var baseURL: URL { URL(string: "https://api.example.com")! }
+
+    public var path: String {
+        switch self {
+        case .getUser(let id): return "/users/\(id)"
+        }
+    }
+
+    public var method: Moya.Method {
+        switch self {
+        case .getUser: return .get
+        }
+    }
+
+    public var task: Task {
+        switch self {
+        case .getUser: return .requestPlain
+        }
+    }
+
+    public var headers: [String : String]? { nil }
+
+    public var sampleData: Data { Data() }
+}

--- a/APIModule/Sources/Domain/APIRequesting.swift
+++ b/APIModule/Sources/Domain/APIRequesting.swift
@@ -4,7 +4,10 @@
 //  
 //  Created by Daiki Fujimori on 2025/08/23
 //  
+import Foundation
 
-public protocol APIRequesting: Sendable {}
+public protocol APIRequesting: Sendable {
+    func fetchUser(id: String, completion: @escaping (Result<Data, Error>) -> Void)
+}
 
 public protocol Endpoint {}

--- a/APIModule/Tests/DataTests/APIClientIntegrationTests.swift
+++ b/APIModule/Tests/DataTests/APIClientIntegrationTests.swift
@@ -1,0 +1,146 @@
+import Testing
+import Foundation
+import Dependencies
+import Alamofire
+import Moya
+
+@testable import Data
+
+struct APIClientIntegrationTests {
+
+    @Test(arguments: [()]) func setUpEach(_: Void) {
+        MockURLProtocol.reset()
+    }
+
+    @Test
+    func pipeline_through_interceptor_and_plugin() async throws {
+        let tokenPlugin = AccessTokenPlugin { _ in "token" }
+        let interceptor = CountingInterceptor()
+
+        MockURLProtocol.requestHandler = { request, _ in
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer token")
+            let data = #"{"id":"123","name":"Alice"}"#.data(using: .utf8)!
+            let resp = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil,
+                                       headerFields: ["Content-Type":"application/json"])!
+            return (resp, data)
+        }
+
+        let session = makeTestingSession(interceptor: interceptor)
+        let provider = MoyaNetworkProvider(session: session, plugins: [tokenPlugin])
+
+        let client = withDependencies { $0.network = provider } operation: { APIClient() }
+
+        let result = await withCheckedContinuation { cont in
+            client.fetchUser(id: "123") { cont.resume(returning: $0) }
+        }
+
+        switch result {
+        case .success(let data):
+            #expect(!data.isEmpty)
+            #expect(interceptor.adaptCount >= 1)
+        case .failure(let error):
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    @Test
+    func parameterized_status_codes() async throws {
+        struct Case { let status: Int; let shouldSucceed: Bool }
+        let cases: [Case] = [
+            .init(status: 200, shouldSucceed: true),
+            .init(status: 201, shouldSucceed: true),
+            .init(status: 204, shouldSucceed: true),
+            .init(status: 400, shouldSucceed: false),
+            .init(status: 401, shouldSucceed: false),
+            .init(status: 403, shouldSucceed: false),
+            .init(status: 404, shouldSucceed: false),
+            .init(status: 429, shouldSucceed: false),
+            .init(status: 500, shouldSucceed: false),
+            .init(status: 502, shouldSucceed: false),
+            .init(status: 503, shouldSucceed: false)
+        ]
+
+        for c in cases {
+            MockURLProtocol.reset()
+            MockURLProtocol.requestHandler = { request, _ in
+                let body = c.shouldSucceed
+                    ? #"{"ok":true}"#.data(using: .utf8)!
+                    : #"{"error":"ng"}"#.data(using: .utf8)!
+                let resp = HTTPURLResponse(url: request.url!, statusCode: c.status, httpVersion: nil, headerFields: nil)!
+                return (resp, body)
+            }
+
+            let provider = MoyaNetworkProvider(session: makeTestingSession())
+            let client = withDependencies { $0.network = provider } operation: { APIClient() }
+
+            let result = await withCheckedContinuation { cont in
+                client.fetchUser(id: "x") { cont.resume(returning: $0) }
+            }
+
+            switch (result, c.shouldSucceed) {
+            case (.success, true): break
+            case (.failure(let err), false):
+                if case let MoyaError.statusCode(res) = err {
+                    #expect(res.statusCode == c.status)
+                } else {
+                    Issue.record("expected statusCode error for \(c.status), got \(err)")
+                }
+            default:
+                Issue.record("mismatch for status \(c.status)")
+            }
+        }
+    }
+
+    @Test
+    func network_error_then_retry_success() async throws {
+        let interceptor = CountingInterceptor()
+
+        MockURLProtocol.requestHandler = { request, attempt in
+            if attempt == 1 {
+                throw AFError.sessionTaskFailed(error: URLError(.timedOut))
+            } else {
+                let data = #"{"id":"999","name":"Bob"}"#.data(using: .utf8)!
+                let resp = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                return (resp, data)
+            }
+        }
+
+        let provider = MoyaNetworkProvider(session: makeTestingSession(interceptor: interceptor))
+        let client = withDependencies { $0.network = provider } operation: { APIClient() }
+
+        let result = await withCheckedContinuation { cont in
+            client.fetchUser(id: "999") { cont.resume(returning: $0) }
+        }
+
+        switch result {
+        case .success(let data):
+            #expect(!data.isEmpty)
+            #expect(interceptor.retryCount == 1)
+        case .failure(let error):
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    @Test
+    func network_error_then_retry_exhausted() async throws {
+        let interceptor = CountingInterceptor()
+
+        MockURLProtocol.requestHandler = { _, _ in
+            throw AFError.sessionTaskFailed(error: URLError(.timedOut))
+        }
+
+        let provider = MoyaNetworkProvider(session: makeTestingSession(interceptor: interceptor))
+        let client = withDependencies { $0.network = provider } operation: { APIClient() }
+
+        let result = await withCheckedContinuation { cont in
+            client.fetchUser(id: "dead") { cont.resume(returning: $0) }
+        }
+
+        switch result {
+        case .success:
+            Issue.record("should have failed")
+        case .failure:
+            #expect(interceptor.retryCount == 1)
+        }
+    }
+}

--- a/APIModule/Tests/DataTests/APIClientTest.swift
+++ b/APIModule/Tests/DataTests/APIClientTest.swift
@@ -1,6 +1,0 @@
-//
-//  APIClientTest.swift
-//  APIClientSample
-//  
-//  Created by Daiki Fujimori on 2025/08/23
-//  

--- a/APIModule/Tests/DataTests/Support/CountingInterceptor.swift
+++ b/APIModule/Tests/DataTests/Support/CountingInterceptor.swift
@@ -1,0 +1,32 @@
+import Alamofire
+
+final class CountingInterceptor: RequestInterceptor {
+    private(set) var adaptCount = 0
+    private(set) var retryCount = 0
+
+    func adapt(_ urlRequest: URLRequest,
+               for session: Session,
+               completion: @escaping (Result<URLRequest, Error>) -> Void) {
+        adaptCount += 1
+        var req = urlRequest
+        req.addValue("Bearer token", forHTTPHeaderField: "Authorization")
+        completion(.success(req))
+    }
+
+    func retry(_ request: Request,
+               for session: Session,
+               dueTo error: Error,
+               completion: @escaping (RetryResult) -> Void) {
+        if retryCount == 0, let afError = error as? AFError {
+            switch afError {
+            case .sessionTaskFailed(let underlying as URLError)
+                where underlying.code == .timedOut || underlying.code == .cannotFindHost || underlying.code == .cannotConnectToHost:
+                retryCount += 1
+                completion(.retryWithDelay(0.05))
+                return
+            default: break
+            }
+        }
+        completion(.doNotRetry)
+    }
+}

--- a/APIModule/Tests/DataTests/Support/MockURLProtocol.swift
+++ b/APIModule/Tests/DataTests/Support/MockURLProtocol.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+final class MockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest, Int) throws -> (HTTPURLResponse, Data))?
+
+    private static var attemptCounts: [URL: Int] = [:]
+    private static let lock = NSLock()
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        MockURLProtocol.lock.lock()
+        let attempt = (MockURLProtocol.attemptCounts[url] ?? 0) + 1
+        MockURLProtocol.attemptCounts[url] = attempt
+        MockURLProtocol.lock.unlock()
+
+        guard let handler = MockURLProtocol.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: NSError(domain: "MockURLProtocol", code: -1))
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request, attempt)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+
+    static func reset() {
+        lock.lock()
+        attemptCounts.removeAll()
+        lock.unlock()
+        requestHandler = nil
+    }
+}

--- a/APIModule/Tests/DataTests/Support/SessionFactory.swift
+++ b/APIModule/Tests/DataTests/Support/SessionFactory.swift
@@ -1,0 +1,9 @@
+import Alamofire
+
+func makeTestingSession(interceptor: RequestInterceptor? = nil) -> Session {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    config.timeoutIntervalForRequest = 5
+    config.timeoutIntervalForResource = 5
+    return Session(configuration: config, interceptor: interceptor)
+}


### PR DESCRIPTION
## Summary
- Implement APIClient backed by Moya/Alamofire and injected via swift-dependencies
- Provide UserAPI target definitions and network provider abstraction
- Add comprehensive integration tests covering interceptor, plugin, status codes, and retry behaviors

## Testing
- `swift test` *(fails: unable to clone dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68b080a7bc2c8331a607455adadae8e2